### PR TITLE
docs: fix Quickstart — add cert setup, dev vs prod paths, and DEPLOYMENT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,32 +30,60 @@ Browser → Nginx → React UI
 - Docker & Docker Compose
 - (For Pi) Raspberry Pi 4 with 4GB+ RAM
 
-### Installation
+---
 
-1. **Clone & Configure**:
+### Option A — Local / Development (recommended for first run)
+
+No SSL certificates required. Uses HTTP with hot-reload.
+
+1. **Clone & configure**
    ```bash
    git clone <your-repo-url>
    cd OZMirror
    cp .env.example .env
-   # Edit .env with your API keys
    ```
+   Open `.env` and set at minimum:
+   - `REDIS_PASSWORD`, `MYSQL_PASSWORD`, `MYSQL_ROOT_PASSWORD` — choose any secure passwords
+   - `API_KEY` — a random 32-char string (e.g. `openssl rand -hex 16`)
+   - Optional: `WEATHER_API_KEY`, Spotify, and Google Calendar keys for those modules
 
-2. **Start Services**:
+2. **Start in dev mode**
    ```bash
-   docker-compose up -d
+   docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
    ```
 
-3. **Open in Browser**:
+3. **Open in browser**
    ```
-   http://localhost:80
+   http://localhost
    ```
 
-### Development Mode
+---
+
+### Option B — Production (HTTPS)
+
+Same `.env` steps as above, then provide SSL certificates **before** starting:
 
 ```bash
-# Start with hot reload
-docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+# Option 1: Self-signed cert (local/testing only — browser will warn)
+openssl req -x509 -newkey rsa:4096 \
+  -keyout nginx/ssl/key.pem \
+  -out nginx/ssl/cert.pem \
+  -days 365 -nodes \
+  -subj "/CN=localhost"
+
+# Option 2: Copy an existing cert/key pair (e.g. from Let's Encrypt)
+cp /path/to/fullchain.pem nginx/ssl/cert.pem
+cp /path/to/privkey.pem   nginx/ssl/key.pem
 ```
+
+Then start:
+```bash
+docker-compose up -d
+```
+
+Access at `https://localhost` (HTTP automatically redirects to HTTPS).
+
+> Cert files are gitignored — never commit them to the repository.
 
 ## Documentation
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,53 @@
+# Deployment Guide
+
+For setup instructions see the [Quick Start](../README.md#quick-start) section in the README.
+
+## Summary
+
+| Mode | Command | Access | Certs required? |
+|------|---------|--------|-----------------|
+| Development | `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d` | `http://localhost` | No |
+| Production | `docker-compose up -d` | `https://localhost` | Yes — place in `nginx/ssl/` |
+
+## SSL Certificates (Production)
+
+Place the following files in `nginx/ssl/` before starting production:
+
+| File | Description |
+|------|-------------|
+| `nginx/ssl/cert.pem` | Full-chain certificate (PEM format) |
+| `nginx/ssl/key.pem` | Private key (PEM format) |
+
+These files are gitignored — never commit them.
+
+**Self-signed (testing only):**
+```bash
+openssl req -x509 -newkey rsa:4096 \
+  -keyout nginx/ssl/key.pem \
+  -out nginx/ssl/cert.pem \
+  -days 365 -nodes \
+  -subj "/CN=localhost"
+```
+
+**Let's Encrypt / existing cert:**
+```bash
+cp /path/to/fullchain.pem nginx/ssl/cert.pem
+cp /path/to/privkey.pem   nginx/ssl/key.pem
+```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and configure:
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `API_KEY` | Yes | Random 32-char key — `openssl rand -hex 16` |
+| `REDIS_PASSWORD` | Yes | Redis auth password |
+| `MYSQL_PASSWORD` | Yes | MySQL user password |
+| `MYSQL_ROOT_PASSWORD` | Yes | MySQL root password |
+| `WEATHER_API_KEY` | Optional | OpenWeatherMap key |
+| `SPOTIFY_CLIENT_ID` | Optional | Spotify app client ID |
+| `SPOTIFY_CLIENT_SECRET` | Optional | Spotify app client secret |
+| `GOOGLE_CALENDAR_CLIENT_ID` | Optional | Google Calendar OAuth client ID |
+| `GOOGLE_CALENDAR_CLIENT_SECRET` | Optional | Google Calendar OAuth client secret |
+| `TZ` | Optional | Timezone (default: `America/New_York`) |


### PR DESCRIPTION
## Summary

- **Quickstart was broken out of the box**: the production nginx config requires `nginx/ssl/cert.pem` and `nginx/ssl/key.pem` (gitignored), so `docker-compose up -d` crashes on the gateway container and the `http://localhost:80` URL in the README never loads
- Split Quickstart into **Option A (dev/HTTP — no certs, recommended for first run)** and **Option B (production/HTTPS)** with `openssl` self-signed and copy-from-existing cert instructions
- Clarified that `.env` requires passwords and a generated `API_KEY`, not just optional module API keys
- Fixed access URL to `http://localhost` (`:80` is redundant)
- Created `docs/DEPLOYMENT.md` — it was linked from the README but the file didn't exist

## Test plan

- [ ] Follow Option A verbatim: `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d` → `http://localhost` loads the UI with no cert setup
- [ ] Follow Option B with the self-signed `openssl` command → `docker-compose up -d` starts successfully, `https://localhost` loads (browser self-signed warning expected)
- [ ] Confirm `docs/DEPLOYMENT.md` link in README resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)