### PR TITLE
fix(ui): correct saveLayout payload to match backend API contract

### DIFF
--- a/ui/src/api/config.ts
+++ b/ui/src/api/config.ts
@@ -20,7 +20,12 @@ export async function fetchLayout(): Promise<LayoutData> {
 }
 
 export async function saveLayout(layout: LayoutData): Promise<void> {
-  await client.put('/layout', layout);
+  const profile = layout.layouts[layout.activeProfile];
+  await client.put('/layout', {
+    profileName: layout.activeProfile,
+    grid: profile.grid,
+    moduleConfigs: profile.moduleConfigs,
+  });
 }
 
 export async function fetchProfiles(): Promise<string[]> {


### PR DESCRIPTION
## Summary

- Fixes #15 — dashboard layout and module changes were not persisting after page refresh
- The `saveLayout()` function in `ui/src/api/config.ts` was sending the full `LayoutData` object to `PUT /api/config/layout`, but the backend expects an `UpdateLayoutRequest` (`{ profileName, grid, moduleConfigs }`)
- The backend's Pydantic model uses `extra="forbid"`, so every save silently failed with a 422; the `catch` blocks only logged to console, giving the user no feedback
- Fix extracts the active profile before the PUT call so the payload matches the backend contract

## Test plan

- [ ] Start the stack (`docker compose up`)
- [ ] Open OZMirror in a browser
- [ ] Enter Edit Mode (`E` key or pencil button)
- [ ] Add a module via the ModulePicker drawer
- [ ] Drag/resize widgets
- [ ] Refresh the page — modules and positions should persist
- [ ] Verify `PUT /api/config/layout` returns `200 {"success": true}` in the Network tab (previously 422)

🤖 Generated with [Claude Code](https://claude.com/claude-code)