### PR TITLE
fix(cors): allow https://ozmirror.azuriki.com as a trusted origin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,14 +33,14 @@ CONFIG_SERVICE_URL=http://config-service:8000
 API_KEY=generate_a_random_32_char_key_here
 
 # Allowed CORS origins for the Config Service (comma-separated)
-ALLOWED_ORIGINS=http://localhost,http://localhost:80
+ALLOWED_ORIGINS=http://localhost,http://localhost:80,https://ozmirror.azuriki.com
 
 # ----------------
 # WebSocket Bridge
 # ----------------
 WEBSOCKET_PORT=8080
 # Allowed CORS origins for the WebSocket Bridge (comma-separated)
-ALLOWED_CORS_ORIGINS=http://localhost,http://localhost:80
+ALLOWED_CORS_ORIGINS=http://localhost,http://localhost:80,https://ozmirror.azuriki.com
 
 # ----------------
 # Module API Keys

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -22,6 +22,7 @@ http {
         default                                  "";
         ~^http://localhost(:[0-9]+)?$            $http_origin;
         ~^http://127\.0\.0\.1(:[0-9]+)?$        $http_origin;
+        ~^https://ozmirror\.azuriki\.com$        $http_origin;
     }
 
     # Upstream services


### PR DESCRIPTION
## Summary

- Fixes the remaining cause of issue #15 — layout changes still not persisting after the payload fix in #16
- `PUT /api/config/layout` is a non-simple HTTP method, so browsers send a CORS preflight (`OPTIONS`) before every write
- The Nginx `$allow_origin` map and both CORS origin env vars only listed `localhost`, so the preflight for `https://ozmirror.azuriki.com` returned an empty `Access-Control-Allow-Origin` — the browser blocked the request entirely, silently
- Adds `https://ozmirror.azuriki.com` to all three allowlists

## Changes

| File | Change |
|------|--------|
| `nginx/nginx.conf` | Added production domain to the `map $http_origin $allow_origin` block |
| `.env.example` | Added production domain to `ALLOWED_ORIGINS` and `ALLOWED_CORS_ORIGINS` |

## Deployment note

After merging, update your live `.env` file with the same addition to `ALLOWED_ORIGINS` and `ALLOWED_CORS_ORIGINS`, then restart:
\`\`\`
docker compose up -d --force-recreate nginx config-service websocket-bridge
\`\`\`

## Test plan

- [ ] Open `https://ozmirror.azuriki.com` in a browser with DevTools → Network open
- [ ] Enter Edit Mode, add a module or drag a widget
- [ ] Confirm `PUT /api/config/layout` returns `200 {"success": true}` (no longer blocked at CORS preflight)
- [ ] Refresh the page — layout changes should persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)