### PR TITLE
chore: add CLAUDE.md with project guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,26 @@
+# OZMirror — Claude Code Guidelines
+
+## Branching & PRs
+
+- **Never commit directly to `main`**
+- All changes must go through a feature/fix branch and a pull request
+- Branch naming: `fix/<short-description>`, `feat/<short-description>`, `chore/<short-description>`
+- Create the PR with `gh pr create` after pushing the branch
+
+## Deployment
+
+The server runs on a dedicated Linux machine. Always use `make deploy` (not `docker compose up`) after pulling new code — it rebuilds images so code changes actually take effect.
+
+```bash
+make deploy   # git pull + rebuild all images + restart
+```
+
+See the Makefile for all available commands (`make help`).
+
+## CORS
+
+The dashboard is accessed at `https://ozmirror.azuriki.com`. Any new domain or IP that needs write access (`PUT`/`DELETE`) must be added to:
+1. `ALLOWED_ORIGINS` and `ALLOWED_CORS_ORIGINS` in `.env`
+2. The `map $http_origin $allow_origin` block in `nginx/nginx.conf`
+
+Omitting either causes layout saves to silently fail with 422.


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` to the repo root. Claude Code reads this file automatically at the start of every session, so it acts as a persistent reminder of project-specific rules.

Documents three guidelines:
- **Branching** — never commit directly to `main`; always use a branch + PR
- **Deployment** — always use `make deploy` (not bare `docker compose up`) so images are rebuilt and code changes actually take effect
- **CORS** — any new domain needs to be added to both `.env` and `nginx/nginx.conf`, or write requests will silently fail

## Test plan

- [ ] Merge and verify Claude Code picks up the guidelines at the start of the next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)