### PR TITLE
chore: remove dead now_playing channel from WebSocket allowlist

### DIFF
--- a/docs/REDIS_CHANNELS.md
+++ b/docs/REDIS_CHANNELS.md
@@ -56,13 +56,12 @@ The WebSocket Bridge enforces the whitelist at connect time.
 | `module:calendar:<detail>` | `module:calendar:events` |
 | `module:rss:<detail>` | `module:rss:feed` |
 | `module:system_stats:<detail>` | `module:system_stats:cpu` |
-| `module:now_playing:<detail>` | `module:now_playing:track` |
 | `module:sticky_notes:<detail>` | `module:sticky_notes:notes` |
 
 ### Regex (enforced in `services/websocket/src/server.ts`)
 
 ```
-^module:(clock|weather|calendar|rss|system_stats|now_playing|sticky_notes):.+$
+^module:(clock|weather|calendar|rss|system_stats|sticky_notes):.+$
 ```
 
 ### Payload shape

--- a/services/websocket/src/server.ts
+++ b/services/websocket/src/server.ts
@@ -33,7 +33,7 @@ function isAllowedOrigin(origin: string): boolean {
 // Both subscribe and publish are restricted to module-owned channels.
 // System/internal channels must not be readable or writable by browser clients.
 const ALLOWED_MODULE_CHANNELS =
-  /^module:(clock|weather|calendar|rss|system_stats|now_playing|sticky_notes):.+$/;
+  /^module:(clock|weather|calendar|rss|system_stats|sticky_notes):.+$/;
 
 // ── HTTP server ────────────────────────────────────────────────────────────
 // Handle /health directly; all other requests are handled by Socket.io.


### PR DESCRIPTION
now_playing has no backing module container, no docker-compose service, and no UI widget. It was never in the v1 bundled modules list in PRODUCT_SPEC.md. Remove it from the ALLOWED_MODULE_CHANNELS regex in the WebSocket bridge and from the REDIS_CHANNELS.md reference table.

https://claude.ai/code/session_01L7FbkDsRovY3z3ULnTKqfR